### PR TITLE
Separate revision and overall progress gadgets

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 ### Overview
 Separated the progress tracking gadgets on the dashboard to clearly distinguish between:
-1. **Overall Progress** - Based on pages completed across all subjects
+1. **Overall Progress** - Based on pages completed + 3 revisions across all subjects
 2. **Revision Progress** - Based on the 3-revision cycle system (0/3, 1/3, 2/3, 3/3)
 
 ### What Changed
@@ -20,15 +20,18 @@ Added new fields to `ProgressStats` interface:
 
 #### 2. Enhanced Progress Calculation (`lib/firestoreHelpers.ts`)
 Updated `calculateProgress` function to:
+- **Calculate overall progress based on BOTH pages AND revisions**
+  - Total work required = Total pages × 4 (initial read + 3 revisions)
+  - Work completed = Pages completed + (Pages × Revisions for completed chapters)
+  - This means 100% = All pages read + All 3 revisions completed
 - Track revision distribution across all chapters
 - Calculate average revision progress (X.X/3.0)
-- Calculate overall progress based on pages completed (not just chapters)
 - Count chapters at each revision level (0, 1, 2, 3)
 
 #### 3. Redesigned Dashboard (`app/dashboard/page.tsx`)
 **Row 1 - Main Stats:**
 - ✅ Exam Countdown (unchanged)
-- ✅ **Overall Progress** - Now shows % of pages completed with "pages completed" label
+- ✅ **Overall Progress** - Now shows % of (pages + 3 revisions) with "pages + 3 revisions" label
 - ✅ **Revision Progress** - NEW! Shows average revision cycle (e.g., "1.5/3")
   - Purple gradient background
   - Displays "avg revisions" subtitle
@@ -42,17 +45,50 @@ Four mini-gadgets showing chapter distribution:
 - 🟡 **2nd Revision** - Chapters at 2/3 revisions (yellow background)
 - 🟢 **3rd Revision** - Chapters at 3/3 revisions (green background)
 
+#### 4. Added Revision Undo Functionality (`app/subjects/[id]/page.tsx`)
+**New Feature - Click to Add or Undo Revisions:**
+- ✅ Click on a **completed revision** (green with ✓) to **undo** it
+- ✅ Click on the **next available revision** (blue) to **complete** it
+- ✅ Disabled revisions (gray) require previous revisions to be completed first
+- ✅ Visual feedback with checkmarks on completed revisions
+- ✅ Tooltip hints: "Click to undo this revision" or "Click to complete this revision"
+
+**How It Works:**
+```
+Example: Chapter has 2 revisions completed [✓ Rev 1] [✓ Rev 2] [ Rev 3]
+- Click Rev 2 → Undoes Rev 2 → [✓ Rev 1] [ Rev 2] [ Rev 3]
+- Click Rev 3 → Completes Rev 3 → [✓ Rev 1] [✓ Rev 2] [✓ Rev 3]
+```
+
 ### Visual Improvements
 - Removed the old "Total Revisions" gadget (which just showed a sum)
 - Added color-coded revision breakdown for better visual tracking
-- Made "Overall Progress" clearly about pages completed
+- Made "Overall Progress" clearly include both pages AND revisions
 - Added visual hierarchy to help users understand their revision status at a glance
+- Added checkmarks (✓) to completed revision buttons
+- Added "(Click to add or undo)" hint text on revision tracking
+
+### Progress Calculation Formula
+**Overall Progress = (Pages Completed + Revision Work) / (Total Pages × 4) × 100%**
+
+Where:
+- **Total Pages × 4** = All pages need to be read once + revised 3 times
+- **Pages Completed** = Sum of all completed pages across all chapters
+- **Revision Work** = For each completed chapter: Total Pages × Revisions Completed
+
+Example:
+- 100 total pages, 50 pages completed, 2 chapters fully completed with 2 revisions each (20 pages each)
+- Work completed = 50 + (20 × 2) + (20 × 2) = 50 + 40 + 40 = 130
+- Total work = 100 × 4 = 400
+- Progress = 130/400 × 100 = 32.5%
 
 ### Benefits
-1. **Clearer Tracking** - Users can now see exactly how many chapters are at each revision stage
-2. **Better Motivation** - Visual breakdown shows progress through the 3-revision system
-3. **Accurate Progress** - Overall progress now accurately reflects pages completed, not just chapters
-4. **Actionable Insights** - Users can identify which chapters need more revision work
+1. **Accurate Overall Progress** - Now reflects the true amount of work (pages + revisions)
+2. **Clearer Tracking** - Users can now see exactly how many chapters are at each revision stage
+3. **Better Motivation** - Visual breakdown shows progress through the 3-revision system
+4. **Flexible Revision Management** - Can undo revisions if marked by mistake or need to redo
+5. **Actionable Insights** - Users can identify which chapters need more revision work
+6. **Realistic Progress** - 100% means truly finishing all work, not just reading pages once
 
 ---
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,62 @@
-# Recent Changes - Production Configuration
+# Recent Changes
+
+## 🎯 Latest Update - Separated Revision and Overall Progress Gadgets (2025-10-03)
+
+### Overview
+Separated the progress tracking gadgets on the dashboard to clearly distinguish between:
+1. **Overall Progress** - Based on pages completed across all subjects
+2. **Revision Progress** - Based on the 3-revision cycle system (0/3, 1/3, 2/3, 3/3)
+
+### What Changed
+
+#### 1. Updated Types (`lib/types.ts`)
+Added new fields to `ProgressStats` interface:
+- `revisionProgress: number` - Average revision cycle progress (0-3 scale)
+- `chaptersAt0Revisions: number` - Chapters with 0 revisions
+- `chaptersAt1Revision: number` - Chapters with 1 revision
+- `chaptersAt2Revisions: number` - Chapters with 2 revisions
+- `chaptersAt3Revisions: number` - Chapters with 3 revisions
+- `totalChapters: number` - Total number of chapters
+
+#### 2. Enhanced Progress Calculation (`lib/firestoreHelpers.ts`)
+Updated `calculateProgress` function to:
+- Track revision distribution across all chapters
+- Calculate average revision progress (X.X/3.0)
+- Calculate overall progress based on pages completed (not just chapters)
+- Count chapters at each revision level (0, 1, 2, 3)
+
+#### 3. Redesigned Dashboard (`app/dashboard/page.tsx`)
+**Row 1 - Main Stats:**
+- ✅ Exam Countdown (unchanged)
+- ✅ **Overall Progress** - Now shows % of pages completed with "pages completed" label
+- ✅ **Revision Progress** - NEW! Shows average revision cycle (e.g., "1.5/3")
+  - Purple gradient background
+  - Displays "avg revisions" subtitle
+  - Shows encouraging messages: "🏆 Master!" (3.0), "🌟 Excellent!" (2.0+), "📚 Good start!" (1.0+)
+- ✅ Daily Streak (unchanged)
+
+**Row 2 - Revision Breakdown (NEW):**
+Four mini-gadgets showing chapter distribution:
+- ⚪ **Not Started** - Chapters at 0/3 revisions (gray background)
+- 🔵 **1st Revision** - Chapters at 1/3 revisions (blue background)
+- 🟡 **2nd Revision** - Chapters at 2/3 revisions (yellow background)
+- 🟢 **3rd Revision** - Chapters at 3/3 revisions (green background)
+
+### Visual Improvements
+- Removed the old "Total Revisions" gadget (which just showed a sum)
+- Added color-coded revision breakdown for better visual tracking
+- Made "Overall Progress" clearly about pages completed
+- Added visual hierarchy to help users understand their revision status at a glance
+
+### Benefits
+1. **Clearer Tracking** - Users can now see exactly how many chapters are at each revision stage
+2. **Better Motivation** - Visual breakdown shows progress through the 3-revision system
+3. **Accurate Progress** - Overall progress now accurately reflects pages completed, not just chapters
+4. **Actionable Insights** - Users can identify which chapters need more revision work
+
+---
+
+# Previous Changes - Production Configuration
 
 ## 🔧 Changes Made for Production Setup
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -60,6 +60,18 @@ Example: Chapter has 2 revisions completed [✓ Rev 1] [✓ Rev 2] [ Rev 3]
 - Click Rev 3 → Completes Rev 3 → [✓ Rev 1] [✓ Rev 2] [✓ Rev 3]
 ```
 
+#### 5. Auto-Refresh Dashboard on Navigation (`app/dashboard/page.tsx`)
+**New Feature - Dashboard Auto-Updates:**
+- ✅ Dashboard automatically refetches data when you navigate back from other pages
+- ✅ Uses browser `visibilitychange` event to detect when page becomes visible
+- ✅ Ensures progress gadgets always show current data
+- ✅ Works seamlessly when undoing revisions in subject pages
+
+**User Experience:**
+1. Go to dashboard → See current progress
+2. Navigate to subject page → Undo a revision
+3. Navigate back to dashboard → **Progress automatically updates!**
+
 ### Visual Improvements
 - Removed the old "Total Revisions" gadget (which just showed a sum)
 - Added color-coded revision breakdown for better visual tracking

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -142,7 +142,7 @@ export default function DashboardPage() {
                 <p className="text-3xl sm:text-4xl font-bold text-gray-900 dark:text-gray-100">
                   {progress?.overallProgress || 0}%
                 </p>
-                <p className="text-gray-500 dark:text-gray-400 text-xs sm:text-sm mt-1">pages completed</p>
+                <p className="text-gray-500 dark:text-gray-400 text-xs sm:text-sm mt-1">pages + 3 revisions</p>
                 {user?.role === 'student' && (progress?.overallProgress || 0) >= 25 && (
                   <p className="text-xs text-pink-500 dark:text-pink-400 mt-1 sm:mt-2 font-medium">
                     {(progress?.overallProgress || 0) >= 100 ? '🎉 Perfect!' : (progress?.overallProgress || 0) >= 75 ? '⭐ Amazing!' : (progress?.overallProgress || 0) >= 50 ? '🌟 Great!' : '🌱 Keep going!'}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -36,6 +36,7 @@ export default function DashboardPage() {
   const [studentName, setStudentName] = useState<string>('');
   const [currentTasks, setCurrentTasks] = useState<Task[]>([]);
   const [loadingData, setLoadingData] = useState(true);
+  const [refreshKey, setRefreshKey] = useState(0);
 
   useEffect(() => {
     if (!loading && !user) {
@@ -88,7 +89,22 @@ export default function DashboardPage() {
       }
     }
     fetchData();
-  }, [user]);
+  }, [user, refreshKey]);
+
+  // Refetch data when page becomes visible (e.g., navigating back from subject page)
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (!document.hidden) {
+        setRefreshKey(prev => prev + 1);
+      }
+    };
+    
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, []);
 
   if (loading || loadingData) {
     return (

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -112,7 +112,7 @@ export default function DashboardPage() {
         <div className="mb-6 sm:mb-8 animate-slide-in-up">
           <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2 flex items-center flex-wrap">
             {user?.role === 'partner' 
-              ? <><span>{studentName}'s Progress Dashboard</span> <span className="ml-2">📊</span></> 
+              ? <><span>{studentName}&apos;s Progress Dashboard</span> <span className="ml-2">📊</span></> 
               : <><span>Welcome back, {user?.name}!</span> <Sparkles className="w-6 h-6 sm:w-8 sm:h-8 ml-2 text-pink-500 dark:text-pink-400 animate-pulse" /></>}
           </h1>
           {user?.role === 'student' && (
@@ -120,8 +120,8 @@ export default function DashboardPage() {
           )}
         </div>
 
-        {/* Stats Grid */}
-        <div className="grid grid-cols-2 md:grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-6 mb-6 sm:mb-8">
+        {/* Stats Grid - Row 1 */}
+        <div className="grid grid-cols-2 md:grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-6 mb-3 sm:mb-6">
           <div className="bg-gradient-to-br from-primary-500 to-primary-600 dark:from-primary-600 dark:to-primary-700 text-white rounded-lg shadow-lg dark:shadow-primary-500/20 p-4 sm:p-6 hover:shadow-xl hover:scale-105 transition-all transform animate-slide-in-up">
             <div className="flex items-center justify-between">
               <div className="flex-1">
@@ -142,7 +142,7 @@ export default function DashboardPage() {
                 <p className="text-3xl sm:text-4xl font-bold text-gray-900 dark:text-gray-100">
                   {progress?.overallProgress || 0}%
                 </p>
-                <p className="text-gray-500 dark:text-gray-400 text-xs sm:text-sm mt-1">completed</p>
+                <p className="text-gray-500 dark:text-gray-400 text-xs sm:text-sm mt-1">pages completed</p>
                 {user?.role === 'student' && (progress?.overallProgress || 0) >= 25 && (
                   <p className="text-xs text-pink-500 dark:text-pink-400 mt-1 sm:mt-2 font-medium">
                     {(progress?.overallProgress || 0) >= 100 ? '🎉 Perfect!' : (progress?.overallProgress || 0) >= 75 ? '⭐ Amazing!' : (progress?.overallProgress || 0) >= 50 ? '🌟 Great!' : '🌱 Keep going!'}
@@ -153,16 +153,21 @@ export default function DashboardPage() {
             </div>
           </div>
 
-          <div className="card hover:shadow-lg hover:scale-105 transition-all transform animate-slide-in-up" style={{ animationDelay: '0.2s' }}>
+          <div className="card hover:shadow-lg hover:scale-105 transition-all transform animate-slide-in-up bg-gradient-to-br from-purple-50 to-indigo-50 dark:from-purple-900/20 dark:to-indigo-900/20" style={{ animationDelay: '0.2s' }}>
             <div className="flex items-center justify-between">
               <div className="flex-1">
-                <p className="text-gray-600 dark:text-gray-400 text-xs sm:text-sm font-medium mb-1">Total Revisions</p>
+                <p className="text-gray-600 dark:text-gray-400 text-xs sm:text-sm font-medium mb-1">Revision Progress</p>
                 <p className="text-3xl sm:text-4xl font-bold text-gray-900 dark:text-gray-100">
-                  {progress?.totalRevisions || 0}
+                  {progress?.revisionProgress?.toFixed(1) || '0.0'}/3
                 </p>
-                <p className="text-gray-500 dark:text-gray-400 text-xs sm:text-sm mt-1">cycles completed</p>
+                <p className="text-gray-500 dark:text-gray-400 text-xs sm:text-sm mt-1">avg revisions</p>
+                {user?.role === 'student' && progress && progress.revisionProgress >= 1 && (
+                  <p className="text-xs text-purple-600 dark:text-purple-400 mt-1 sm:mt-2 font-medium">
+                    {progress.revisionProgress >= 3 ? '🏆 Master!' : progress.revisionProgress >= 2 ? '🌟 Excellent!' : '📚 Good start!'}
+                  </p>
+                )}
               </div>
-              <BookOpen className="w-10 h-10 sm:w-12 sm:h-12 text-blue-500 dark:text-blue-400 animate-wiggle flex-shrink-0" />
+              <BookOpen className="w-10 h-10 sm:w-12 sm:h-12 text-purple-500 dark:text-purple-400 animate-wiggle flex-shrink-0" />
             </div>
           </div>
 
@@ -180,6 +185,63 @@ export default function DashboardPage() {
             </div>
           </div>
         </div>
+
+        {/* Revision Breakdown - Row 2 */}
+        {progress && (
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3 sm:gap-4 mb-6 sm:mb-8">
+            <div className="card bg-gray-50 dark:bg-gray-800 p-3 sm:p-4 hover:shadow-md transition-all">
+              <div className="flex items-center justify-between">
+                <div className="flex-1">
+                  <p className="text-gray-600 dark:text-gray-400 text-xs font-medium mb-1">Not Started</p>
+                  <p className="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-gray-100">
+                    {progress.chaptersAt0Revisions}
+                  </p>
+                  <p className="text-gray-500 dark:text-gray-400 text-xs mt-1">chapters (0/3)</p>
+                </div>
+                <div className="text-2xl">⚪</div>
+              </div>
+            </div>
+
+            <div className="card bg-blue-50 dark:bg-blue-900/20 p-3 sm:p-4 hover:shadow-md transition-all">
+              <div className="flex items-center justify-between">
+                <div className="flex-1">
+                  <p className="text-gray-600 dark:text-gray-400 text-xs font-medium mb-1">1st Revision</p>
+                  <p className="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-gray-100">
+                    {progress.chaptersAt1Revision}
+                  </p>
+                  <p className="text-gray-500 dark:text-gray-400 text-xs mt-1">chapters (1/3)</p>
+                </div>
+                <div className="text-2xl">🔵</div>
+              </div>
+            </div>
+
+            <div className="card bg-yellow-50 dark:bg-yellow-900/20 p-3 sm:p-4 hover:shadow-md transition-all">
+              <div className="flex items-center justify-between">
+                <div className="flex-1">
+                  <p className="text-gray-600 dark:text-gray-400 text-xs font-medium mb-1">2nd Revision</p>
+                  <p className="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-gray-100">
+                    {progress.chaptersAt2Revisions}
+                  </p>
+                  <p className="text-gray-500 dark:text-gray-400 text-xs mt-1">chapters (2/3)</p>
+                </div>
+                <div className="text-2xl">🟡</div>
+              </div>
+            </div>
+
+            <div className="card bg-green-50 dark:bg-green-900/20 p-3 sm:p-4 hover:shadow-md transition-all">
+              <div className="flex items-center justify-between">
+                <div className="flex-1">
+                  <p className="text-gray-600 dark:text-gray-400 text-xs font-medium mb-1">3rd Revision</p>
+                  <p className="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-gray-100">
+                    {progress.chaptersAt3Revisions}
+                  </p>
+                  <p className="text-gray-500 dark:text-gray-400 text-xs mt-1">chapters (3/3)</p>
+                </div>
+                <div className="text-2xl">🟢</div>
+              </div>
+            </div>
+          </div>
+        )}
 
         {/* Current Tasks (Students Only) */}
         {user?.role === 'student' && currentTasks.length > 0 && (

--- a/lib/firestoreHelpers.ts
+++ b/lib/firestoreHelpers.ts
@@ -565,9 +565,23 @@ export async function calculateProgress(userId: string): Promise<ProgressStats> 
     };
   }
 
-  // Calculate overall progress based on pages completed across all subjects
-  const overallProgress = totalPagesAcrossAllSubjects > 0 
-    ? Math.round((totalPagesCompletedAcrossAllSubjects / totalPagesAcrossAllSubjects) * 100) 
+  // Calculate overall progress based on pages completed AND revisions
+  // Total work = (all pages) + (all pages × 3 revisions) = pages × 4
+  // Completed work = pages completed + (pages × revisions completed)
+  // Note: Each revision counts as completing all pages of that chapter again
+  let totalWorkCompleted = totalPagesCompletedAcrossAllSubjects;
+  
+  // Add revision work: each revision = completing all pages of that chapter
+  chapters.forEach(ch => {
+    // Only count revision work for fully completed chapters
+    if (ch.completedPages >= ch.totalPages) {
+      totalWorkCompleted += (ch.totalPages * ch.revisionsCompleted);
+    }
+  });
+  
+  const totalWorkRequired = totalPagesAcrossAllSubjects * 4; // pages + 3 revisions
+  const overallProgress = totalWorkRequired > 0 
+    ? Math.round((totalWorkCompleted / totalWorkRequired) * 100) 
     : 0;
   
   // Calculate average revision progress (0-3 scale)

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -65,7 +65,13 @@ export interface ProgressStats {
       percentage: number;
     };
   };
-  overallProgress: number;
-  totalRevisions: number;
+  overallProgress: number; // Based on pages completed
+  totalRevisions: number; // Sum of all revision cycles completed
+  revisionProgress: number; // Average revision cycle progress (0-3)
+  chaptersAt0Revisions: number;
+  chaptersAt1Revision: number;
+  chaptersAt2Revisions: number;
+  chaptersAt3Revisions: number;
+  totalChapters: number;
 }
 


### PR DESCRIPTION
Separate "Overall Progress" and "Revision Progress" gadgets and add a revision breakdown to provide clearer, more actionable insights into study progress.

This change distinguishes between overall content completion (now based on pages) and revision cycle progress, offering a detailed view of chapters at each revision stage (0/3, 1/3, 2/3, 3/3).

---
<a href="https://cursor.com/background-agent?bcId=bc-a40609a6-3e71-4e46-8856-503cbc902574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a40609a6-3e71-4e46-8856-503cbc902574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

